### PR TITLE
Add '--allow-incomplete-classpath' to build-native-image.sh file

### DIFF
--- a/examples/greeting-service/build-native-image.sh
+++ b/examples/greeting-service/build-native-image.sh
@@ -2,6 +2,7 @@
 java -cp build/libs/greeting-service-all.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
 native-image --no-server \
              --class-path build/libs/greeting-service-all.jar \
+	     --allow-incomplete-classpath \
              -H:ReflectionConfigurationFiles=build/reflect.json \
              -H:EnableURLProtocols=http \
              -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \


### PR DESCRIPTION
I received the following error when executing the build-native-image.sh script:

Error: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved type during parsing: groovy.lang.GroovySystem. To diagnose the issue you can use the --allow-incomplete-classpath option. The missing type is then reported at run time when it is accessed the first time.

As shown in the error message, adding the --allow-incomplete-classpath parameter to the native-image utility helped, that is generate the greeting-service executable file, but there was an additional error involving log4j:

ERROR StatusLogger Unable to create class org.apache.logging.slf4j.SLF4JLoggerContextFactory specified in provider URL null
 java.lang.IllegalStateException: slf4j-impl jar is mutually exclusive with log4j-to-slf4j jar (the first routes calls from SLF4J to Log4j, the second from Log4j to SLF4J)

I can certainly look into this one as well, but I thought that I would at least add the updated build-native-image.sh file for now.

Thanks and Happy New Year!

Mike.
