### PR TITLE
Documentation for different annotation processors

### DIFF
--- a/src/main/docs/guide/springToMicronaut/springToMicronautStart.adoc
+++ b/src/main/docs/guide/springToMicronaut/springToMicronautStart.adoc
@@ -6,7 +6,7 @@ plugins {
     id "java"
     id "org.springframework.boot" version "2.1.0.RELEASE"
     id "io.spring.dependency-management" version "1.0.6.RELEASE"
-    id "net.ltgt.apt" version "0.19"                    // for Java applications
+    id "net.ltgt.apt" version "0.19"                    // for Java and Groovy applications
     id "org.jetbrains.kotlin:kapt" version "1.2.61"     // for Kotlin applications
 }
 
@@ -20,6 +20,11 @@ dependencies {
     kapt "io.micronaut:micronaut-inject-java:{micronautVersion}"
     kapt "io.micronaut:micronaut-validation:{micronautVersion}"
     kapt "io.micronaut.spring:micronaut-spring-annotation:{version}"
+    
+    // for Groovy applications
+    compileOnly "io.micronaut:micronaut-inject-groovy:$micronautVersion"
+    compileOnly "io.micronaut:micronaut-validation:$micronautVersion"
+    compileOnly "io.micronaut.spring:micronaut-spring-annotation:$micronautSpringVersion"
 
     compile "io.micronaut:micronaut-inject:{micronautVersion}"
     compile("org.springframework.boot:spring-boot-starter")

--- a/src/main/docs/guide/springToMicronaut/springToMicronautStart.adoc
+++ b/src/main/docs/guide/springToMicronaut/springToMicronautStart.adoc
@@ -29,7 +29,6 @@ dependencies {
     compile "io.micronaut:micronaut-inject:{micronautVersion}"
     compile("org.springframework.boot:spring-boot-starter")
     ...
-
 }
 ----
 

--- a/src/main/docs/guide/springToMicronaut/springToMicronautStart.adoc
+++ b/src/main/docs/guide/springToMicronaut/springToMicronautStart.adoc
@@ -6,13 +6,20 @@ plugins {
     id "java"
     id "org.springframework.boot" version "2.1.0.RELEASE"
     id "io.spring.dependency-management" version "1.0.6.RELEASE"
-    id "net.ltgt.apt" version "0.19"
+    id "net.ltgt.apt" version "0.19"                    // for Java applications
+    id "org.jetbrains.kotlin:kapt" version "1.2.61"     // for Kotlin applications
 }
 
 dependencies {
+    // for Java applications
     annotationProcessor "io.micronaut:micronaut-inject-java:{micronautVersion}"
-    annotationProcessor "io.micronaut:micronaut-validation::{micronautVersion}"
+    annotationProcessor "io.micronaut:micronaut-validation:{micronautVersion}"
     annotationProcessor "io.micronaut.spring:micronaut-spring-annotation:{version}"
+
+    // for Kotlin applications
+    kapt "io.micronaut:micronaut-inject-java:{micronautVersion}"
+    kapt "io.micronaut:micronaut-validation:{micronautVersion}"
+    kapt "io.micronaut.spring:micronaut-spring-annotation:{version}"
 
     compile "io.micronaut:micronaut-inject:{micronautVersion}"
     compile("org.springframework.boot:spring-boot-starter")


### PR DESCRIPTION
See https://github.com/micronaut-projects/micronaut-spring/issues/10#issuecomment-457577264

In the documentation, the Gradle dependencies are only for Java apps. When following along, this leads to errors when the app uses, for example, Kotlin

TODO:
- [x] Kotlin
- [x] Groovy
