### PR TITLE
Fix a typo in pom.xml

### DIFF
--- a/examples/greeting-service/pom.xml
+++ b/examples/greeting-service/pom.xml
@@ -47,7 +47,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomca</artifactId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
I found and fixed the misspelled dependency, 'spring-boot-starter-tomcat'.
