### PR TITLE
Fix for NPE in MicronautBeanFactory

### DIFF
--- a/spring-context/src/main/java/io/micronaut/spring/context/factory/MicronautBeanFactory.java
+++ b/spring-context/src/main/java/io/micronaut/spring/context/factory/MicronautBeanFactory.java
@@ -666,7 +666,7 @@ public class MicronautBeanFactory extends DefaultListableBeanFactory implements 
     @Override
     public org.springframework.beans.factory.config.BeanDefinition getBeanDefinition(String beanName) throws NoSuchBeanDefinitionException {
         final BeanDefinition<?> definition = beanDefinitionMap.get(beanName);
-        if (definition.isEnabled(beanContext)) {
+        if (definition != null && definition.isEnabled(beanContext)) {
             final GenericBeanDefinition genericBeanDefinition = new GenericBeanDefinition();
             genericBeanDefinition.setBeanClass(definition.getBeanType());
             return genericBeanDefinition;


### PR DESCRIPTION
Fixes #156 .

Added simple null check before dereferencing. Will fall through to throwing `NoSuchBeanDefinitionException` if reference is null (which seems to be expected behavior at least by some of Spring applications).