### PR TITLE
Update doGetBean method impl to resolve qualier from NameResolver

### DIFF
--- a/spring-context/src/main/java/io/micronaut/spring/context/factory/MicronautBeanFactory.java
+++ b/spring-context/src/main/java/io/micronaut/spring/context/factory/MicronautBeanFactory.java
@@ -728,8 +728,10 @@ public class MicronautBeanFactory extends DefaultListableBeanFactory implements 
                                 final String annotationType = finalDefinition.getAnnotationNameByStereotype(AnnotationUtil.QUALIFIER).orElse(null);
                                 if (annotationType != null) {
                                     return Qualifiers.byAnnotation(finalDefinition, annotationType);
+                                } else if (finalDefinition instanceof NameResolver) {
+                                    return ((NameResolver) finalDefinition).resolveName().map(Qualifiers::byName).orElse(null);
                                 }
-                                return null;
+                        return null;
                             }
                     );
             if (q != null) {


### PR DESCRIPTION
This implementation allows doGetBean method implementation to resolve bean from name "java.util.concurrent.ExecutorService(io)".  Earlier this worked only with following : 

```
beanFactory.getBean("java.util.concurrent.ExecutorService(io)")
```
Whereas, calling `doGetBean(name, requiredType, args, typeCheckOnly)` throws `NonUniqueBeanException` because it eventually ends up calling `getBeanByType` and there are 2 implementation for the same as:

 1.  java.util.concurrent.ExecutorService(io) 
 2. java.util.concurrent.ExecutorService(scheduled)