### PR TITLE
Correct docs to reflect removal of `io.micronaut.spring/tx/annotation/Transactional`

### DIFF
--- a/src/main/docs/guide/springToMicronaut/springAnnotations.adoc
+++ b/src/main/docs/guide/springToMicronaut/springAnnotations.adoc
@@ -59,7 +59,7 @@ The following table summarizes the annotations that Micronaut for Spring support
 |Example `@Scheduled`. Requires `micronaut-runtime` dependency.
 
 |link:{springapi}org/springframework/transaction/annotation/Transactional.html[@Transactional]
-|link:{micronautapi}spring/tx/annotation/Transactional.html[@Transactional]
+|link:{micronautapi}spring/tx/annotation/TransactionInterceptor.html[TransactionInterceptor]
 |Example `@Transactional`. Requires `micronaut-spring` dependency.
 
 |link:{springapi}org/springframework/cache/annotation/Cacheable.html[@Cacheable]


### PR DESCRIPTION
Correct docs to reflect removal of `io.micronaut.spring/tx/annotation//Transactional`