### PR TITLE
Expose managed versions for spring libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,17 +5,6 @@ plugins {
 }
 
 subprojects { Project subproject ->
-    subproject.configurations.all {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            String group = details.requested.group
-            if (group == 'org.springframework') {
-                details.useVersion(springVersion)
-            }
-            if (group == 'org.springframework.boot') {
-                details.useVersion(springBootVersion)
-            }
-        }
-    }
     tasks.withType(Test) {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
             jvmArgs '--enable-preview'

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.spring-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.spring-module.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.boms.spring))
+    testImplementation(platform(libs.boms.spring))
     compileOnly 'com.google.code.findbugs:jsr305' // for "warning: unknown enum constant When.MAYBE"
     testCompileOnly 'com.google.code.findbugs:jsr305' // for "warning: unknown enum constant When.MAYBE"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,12 @@
-projectVersion=4.1.1-SNAPSHOT
+projectVersion=4.2.0-SNAPSHOT
 projectGroup=io.micronaut.spring
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.3.4
-micronautTestVersion=3.0.5
+micronautVersion=3.4.4
+micronautTestVersion=3.1.1
 
 groovyVersion=3.0.10
 spockVersion=2.1-groovy-3.0
-
-springVersion=5.3.9
-springBootVersion=2.5.3
 
 title=Micronaut for Spring
 projectDesc=Extensions to integrate Micronaut and Spring
@@ -17,9 +14,8 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-spring
 developers=Graeme Rocher
 
-githubCoreBranch=3.4.x
+githubCoreBranch=3.5.x
 bomProperty=micronautSpringVersion
-bomProperties=springVersion,springBootVersion
 
 springbootapi=https://docs.spring.io/spring-boot/docs/current/api
 micronautcache=https://micronaut-projects.github.io/micronaut-cache/latest/api/io/micronaut/cache/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,12 +10,14 @@ managed-spring-boot = { module = 'org.springframework.boot:spring-boot', version
 managed-spring-boot-starter = { module = 'org.springframework.boot:spring-boot-starter', version.ref = 'managed-spring-boot' }
 managed-spring-boot-starter-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'managed-spring-boot' }
 
-managed-spring = { module = 'org.springframework:spring-core', version.ref = 'managed-spring' }
-managed-spring-context = { module = 'org.springframework:spring-context', version.ref = 'managed-spring' }
-managed-spring-tx = { module = 'org.springframework:spring-tx', version.ref = 'managed-spring' }
-managed-spring-orm = { module = 'org.springframework:spring-orm', version.ref = 'managed-spring' }
-managed-spring-jdbc = { module = 'org.springframework:spring-jdbc', version.ref = 'managed-spring' }
-managed-spring-web = { module = 'org.springframework:spring-web', version.ref = 'managed-spring' }
+
+boms-spring = { module = 'org.springframework:spring-framework-bom', version.ref = 'managed-spring' }
+spring-core = { module = 'org.springframework:spring-core' }
+spring-context = { module = 'org.springframework:spring-context' }
+spring-tx = { module = 'org.springframework:spring-tx' }
+spring-orm = { module = 'org.springframework:spring-orm' }
+spring-jdbc = { module = 'org.springframework:spring-jdbc' }
+spring-web = { module = 'org.springframework:spring-web' }
 
 spring-boot-actuator = { module = 'org.springframework.boot:spring-boot-actuator', version.ref = 'managed-spring-boot' }
 spring-boot-autoconfigure = { module = 'org.springframework.boot:spring-boot-autoconfigure', version.ref = 'managed-spring-boot' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,32 @@
 [versions]
-boot = '2.5.12'
+managed-spring-boot = '2.5.12'
+managed-spring = '5.3.20'
+
 junit = '5.8.2'
-micronaut-cache = '3.0.0'
 servlet-api = '4.0.1'
-spring = '5.3.20'
 
 [libraries]
-boot = { module = 'org.springframework.boot:spring-boot', version.ref = 'boot' }
-boot-actuator = { module = 'org.springframework.boot:spring-boot-actuator', version.ref = 'boot' }
-boot-autoconfigure = { module = 'org.springframework.boot:spring-boot-autoconfigure', version.ref = 'boot' }
-boot-thymeleaf = { module = 'org.springframework.boot:spring-boot-starter-thymeleaf', version.ref = 'boot' }
-boot-tomcat = { module = 'org.springframework.boot:spring-boot-starter-tomcat', version.ref = 'boot' }
-boot-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'boot' }
+managed-spring-boot = { module = 'org.springframework.boot:spring-boot', version.ref = 'managed-spring-boot' }
+managed-spring-boot-starter = { module = 'org.springframework.boot:spring-boot-starter', version.ref = 'managed-spring-boot' }
+managed-spring-boot-starter-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'managed-spring-boot' }
+
+managed-spring = { module = 'org.springframework:spring-core', version.ref = 'managed-spring' }
+managed-spring-context = { module = 'org.springframework:spring-context', version.ref = 'managed-spring' }
+managed-spring-tx = { module = 'org.springframework:spring-tx', version.ref = 'managed-spring' }
+managed-spring-orm = { module = 'org.springframework:spring-orm', version.ref = 'managed-spring' }
+managed-spring-jdbc = { module = 'org.springframework:spring-jdbc', version.ref = 'managed-spring' }
+managed-spring-web = { module = 'org.springframework:spring-web', version.ref = 'managed-spring' }
+
+spring-boot-actuator = { module = 'org.springframework.boot:spring-boot-actuator', version.ref = 'managed-spring-boot' }
+spring-boot-autoconfigure = { module = 'org.springframework.boot:spring-boot-autoconfigure', version.ref = 'managed-spring-boot' }
+spring-boot-starter-thymeleaf = { module = 'org.springframework.boot:spring-boot-starter-thymeleaf', version.ref = 'managed-spring-boot' }
+spring-boot-starter-tomcat = { module = 'org.springframework.boot:spring-boot-starter-tomcat', version.ref = 'managed-spring-boot' }
+
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }
-micronaut-cache = { module = 'io.micronaut.cache:micronaut-cache-core', version.ref = 'micronaut-cache' }
+
 servlet-api = { module = 'javax.servlet:javax.servlet-api', version.ref = 'servlet-api' }
-spring-context = { module = 'org.springframework:spring-context', version.ref = 'spring' }
-spring-core = { module = 'org.springframework:spring-core', version.ref = 'spring' }
-spring-jdbc = { module = 'org.springframework:spring-jdbc', version.ref = 'spring' }
-spring-test = { module = 'org.springframework:spring-test', version.ref = 'spring' }
-spring-tx = { module = 'org.springframework:spring-tx', version.ref = 'spring' }
-spring-web = { module = 'org.springframework:spring-web', version.ref = 'spring' }
+
+spring-test = { module = 'org.springframework:spring-test', version.ref = 'managed-spring' }
+
+spock-spring = { module = 'org.spockframework:spock-spring' }

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,13 +23,6 @@ include 'test-suite'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
 
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-    }
-    versionCatalogs {
-        mn {
-            from "io.micronaut:micronaut-bom:${providers.gradleProperty('micronautVersion').get()}"
-        }
-    }
+micronautBuild {
+    importMicronautCatalog()
 }

--- a/spring-annotation/build.gradle
+++ b/spring-annotation/build.gradle
@@ -3,17 +3,18 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor mn.micronaut.inject.java
     api mn.micronaut.inject
     api mn.micronaut.aop
     api mn.micronaut.validation
+
     implementation projects.springContext
     implementation mn.micronaut.runtime
-    implementation libs.micronaut.cache
+    implementation mn.micronaut.cache.core
+
     testAnnotationProcessor mn.micronaut.inject.java
     testImplementation mn.micronaut.inject.groovy
     testImplementation projects.spring
-    testImplementation libs.spring.tx
+    testImplementation libs.managed.spring.tx
 }
 
 compileTestGroovy.options.forkOptions.jvmArgs =['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/spring-annotation/build.gradle
+++ b/spring-annotation/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.boms.spring))
     api mn.micronaut.inject
     api mn.micronaut.aop
     api mn.micronaut.validation
@@ -14,7 +15,7 @@ dependencies {
     testAnnotationProcessor mn.micronaut.inject.java
     testImplementation mn.micronaut.inject.groovy
     testImplementation projects.spring
-    testImplementation libs.managed.spring.tx
+    testImplementation libs.spring.tx
 }
 
 compileTestGroovy.options.forkOptions.jvmArgs =['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/spring-bom/build.gradle
+++ b/spring-bom/build.gradle
@@ -1,10 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.bom"
 }
-dependencies {
-    constraints {
-        api libs.boot
-        api libs.spring.context
-        api libs.spring.web
-    }
-}

--- a/spring-boot-annotation/build.gradle
+++ b/spring-boot-annotation/build.gradle
@@ -4,11 +4,13 @@ plugins {
 
 dependencies {
     implementation projects.springAnnotation
+
     api mn.micronaut.inject
     api mn.micronaut.runtime
-    testImplementation projects.springBoot
+
     testAnnotationProcessor mn.micronaut.inject.java
-    testImplementation libs.boot
-    testImplementation libs.boot.autoconfigure
-    testImplementation libs.boot.actuator
+    testImplementation projects.springBoot
+    testImplementation libs.managed.spring.boot
+    testImplementation libs.spring.boot.autoconfigure
+    testImplementation libs.spring.boot.actuator
 }

--- a/spring-boot/build.gradle
+++ b/spring-boot/build.gradle
@@ -3,21 +3,23 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor mn.micronaut.inject.java
     api projects.springContext
-    api libs.boot
-    compileOnly libs.boot.autoconfigure
+    api libs.managed.spring.boot
+
+    compileOnly libs.spring.boot.autoconfigure
 
     testAnnotationProcessor mn.micronaut.inject.java
     testAnnotationProcessor projects.springBootAnnotation
     testAnnotationProcessor projects.springWebAnnotation
+
     testImplementation projects.springWeb
     testImplementation mn.micronaut.management
     testImplementation mn.micronaut.http.client
     testImplementation mn.micronaut.http.server.netty
-    testImplementation libs.boot.autoconfigure
-    testImplementation libs.boot.actuator
+    testImplementation libs.spring.boot.autoconfigure
+    testImplementation libs.spring.boot.actuator
     testImplementation libs.servlet.api
-    testRuntimeOnly libs.boot.web
-    testRuntimeOnly libs.boot.tomcat
+
+    testRuntimeOnly libs.managed.spring.boot.starter.web
+    testRuntimeOnly libs.spring.boot.starter.tomcat
 }

--- a/spring-context/build.gradle
+++ b/spring-context/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api libs.managed.spring.context
+    api libs.spring.context
     api mn.micronaut.aop
     api mn.micronaut.inject
 

--- a/spring-context/build.gradle
+++ b/spring-context/build.gradle
@@ -5,21 +5,21 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor mn.micronaut.inject.java
-    api libs.spring.context
+    api libs.managed.spring.context
     api mn.micronaut.aop
     api mn.micronaut.inject
 
     implementation projects.spring
-    implementation libs.micronaut.cache
+    implementation mn.micronaut.cache.core
 
-    testImplementation mn.micronaut.runtime
     testAnnotationProcessor mn.micronaut.inject.java
     testAnnotationProcessor projects.springAnnotation
 
+    testImplementation mn.micronaut.runtime
     testImplementation mn.micronaut.inject.java
-    testImplementation  projects.springAnnotation
+    testImplementation projects.springAnnotation
     testImplementation mn.micronaut.inject.java.test
+
     if (!JavaVersion.current().isJava9Compatible()) {
         testImplementation files(Jvm.current().toolsJar)
     }

--- a/spring-context/src/main/java/io/micronaut/spring/context/MicronautApplicationContext.java
+++ b/spring-context/src/main/java/io/micronaut/spring/context/MicronautApplicationContext.java
@@ -220,6 +220,11 @@ public class MicronautApplicationContext implements ManagedApplicationContext, C
     }
 
     @Override
+    public <A extends Annotation> A findAnnotationOnBean(String beanName, Class<A> annotationType, boolean allowFactoryBeanInit) throws NoSuchBeanDefinitionException {
+        return beanFactory.findAnnotationOnBean(beanName, annotationType, allowFactoryBeanInit);
+    }
+
+    @Override
     public Object getBean(String name) throws BeansException {
         return beanFactory.getBean(name);
     }

--- a/spring-web/build.gradle
+++ b/spring-web/build.gradle
@@ -3,23 +3,27 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor mn.micronaut.inject.java
     api projects.springContext
-    api libs.spring.web
+    api libs.managed.spring.web
     api mn.reactor
+
     implementation mn.micronaut.http
+
     compileOnly mn.micronaut.http.server.netty
     compileOnly 'io.micronaut.views:micronaut-views-core'
+
     testAnnotationProcessor mn.micronaut.inject.java
     testAnnotationProcessor projects.springAnnotation
     testAnnotationProcessor projects.springWebAnnotation
-    testImplementation libs.spring.web
+
+    testImplementation libs.managed.spring.web
     testImplementation mn.micronaut.inject.java
     testImplementation mn.micronaut.validation
     testImplementation mn.micronaut.http.client
     testImplementation mn.micronaut.http.server.netty
+
     testRuntimeOnly 'io.micronaut.views:micronaut-views-thymeleaf'
-    testRuntimeOnly libs.boot.thymeleaf
+    testRuntimeOnly libs.spring.boot.starter.thymeleaf
 }
 
 //compileTestJava.options.fork = true

--- a/spring-web/build.gradle
+++ b/spring-web/build.gradle
@@ -3,8 +3,9 @@ plugins {
 }
 
 dependencies {
+    api(platform(libs.boms.spring))
     api projects.springContext
-    api libs.managed.spring.web
+    api libs.spring.web
     api mn.reactor
 
     implementation mn.micronaut.http
@@ -16,7 +17,6 @@ dependencies {
     testAnnotationProcessor projects.springAnnotation
     testAnnotationProcessor projects.springWebAnnotation
 
-    testImplementation libs.managed.spring.web
     testImplementation mn.micronaut.inject.java
     testImplementation mn.micronaut.validation
     testImplementation mn.micronaut.http.client

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -3,21 +3,19 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor mn.micronaut.inject.java
-
-    api libs.spring.core
-    api libs.spring.tx
-    api libs.spring.context
+    api libs.managed.spring
+    api libs.managed.spring.tx
+    api libs.managed.spring.context
     api mn.micronaut.inject
     api mn.micronaut.aop
 
-    compileOnly libs.spring.jdbc
+    compileOnly libs.managed.spring.jdbc
     compileOnly mn.micronaut.test.core
 
     testAnnotationProcessor mn.micronaut.inject.java
     testImplementation mn.micronaut.runtime
     testCompileOnly mn.micronaut.inject.groovy
 
-    testImplementation "org.spockframework:spock-spring:$spockVersion"
+    testImplementation libs.spock.spring
     testImplementation libs.spring.test
 }

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 dependencies {
-    api libs.managed.spring
-    api libs.managed.spring.tx
-    api libs.managed.spring.context
+    api libs.spring.core
+    api libs.spring.tx
+    api libs.spring.context
     api mn.micronaut.inject
     api mn.micronaut.aop
 
-    compileOnly libs.managed.spring.jdbc
+    compileOnly libs.spring.jdbc
     compileOnly mn.micronaut.test.core
 
     testAnnotationProcessor mn.micronaut.inject.java

--- a/spring/src/test/groovy/io/micronaut/spring/beans/MicronautBeanProcessorByAnnotationTypeSpec.groovy
+++ b/spring/src/test/groovy/io/micronaut/spring/beans/MicronautBeanProcessorByAnnotationTypeSpec.groovy
@@ -26,7 +26,6 @@ import org.springframework.test.context.TestExecutionListeners
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener
 import spock.lang.Specification
 
-
 @ContextConfiguration(classes = [ByAnnotationTypeConfig])
 @TestExecutionListeners(value = [DependencyInjectionTestExecutionListener])
 class MicronautBeanProcessorByAnnotationTypeSpec extends Specification {


### PR DESCRIPTION
We currently have versions for splring and spring-boot defined in the core catalog

This becomes a chore to keep in line when renovate spots a new release of Spring.

This change exports these spring libraries as managed versions in the BOM, so we
can remove these versions in core when we integrate the micronaut-spring BOM into
core.

Currently, the bom for this module is unused in core.

I believe there was also an issue whereby this app had upgraded to 5.3.20 of Spring,
but the property in gradle.properties was still on 5.3.9.  I have removed this property
and the resolution strategy, and added the new method required by MicronautApplicationContext.