### PR TITLE
Replace catalog dependencies in core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,13 +10,13 @@ managed-spring-boot = { module = 'org.springframework.boot:spring-boot', version
 managed-spring-boot-starter = { module = 'org.springframework.boot:spring-boot-starter', version.ref = 'managed-spring-boot' }
 managed-spring-boot-starter-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'managed-spring-boot' }
 
+managed-spring = { module = 'org.springframework:spring-core', version.ref = 'managed-spring' }
+managed-spring-context = { module = 'org.springframework:spring-context', version.ref = 'managed-spring' }
+managed-spring-tx = { module = 'org.springframework:spring-tx', version.ref = 'managed-spring' }
+managed-spring-orm = { module = 'org.springframework:spring-orm', version.ref = 'managed-spring' }
+managed-spring-jdbc = { module = 'org.springframework:spring-jdbc', version.ref = 'managed-spring' }
 
 boms-spring = { module = 'org.springframework:spring-framework-bom', version.ref = 'managed-spring' }
-spring-core = { module = 'org.springframework:spring-core' }
-spring-context = { module = 'org.springframework:spring-context' }
-spring-tx = { module = 'org.springframework:spring-tx' }
-spring-orm = { module = 'org.springframework:spring-orm' }
-spring-jdbc = { module = 'org.springframework:spring-jdbc' }
 spring-web = { module = 'org.springframework:spring-web' }
 
 spring-boot-actuator = { module = 'org.springframework.boot:spring-boot-actuator', version.ref = 'managed-spring-boot' }

--- a/spring-annotation/build.gradle
+++ b/spring-annotation/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testAnnotationProcessor mn.micronaut.inject.java
     testImplementation mn.micronaut.inject.groovy
     testImplementation projects.spring
-    testImplementation libs.spring.tx
+    testImplementation libs.managed.spring.tx
 }
 
 compileTestGroovy.options.forkOptions.jvmArgs =['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/spring-context/build.gradle
+++ b/spring-context/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api libs.spring.context
+    api libs.managed.spring.context
     api mn.micronaut.aop
     api mn.micronaut.inject
 

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 dependencies {
-    api libs.spring.core
-    api libs.spring.tx
-    api libs.spring.context
+    api libs.managed.spring
+    api libs.managed.spring.tx
+    api libs.managed.spring.context
     api mn.micronaut.inject
     api mn.micronaut.aop
 
-    compileOnly libs.spring.jdbc
+    compileOnly libs.managed.spring.jdbc
     compileOnly mn.micronaut.test.core
 
     testAnnotationProcessor mn.micronaut.inject.java


### PR DESCRIPTION
We have dependencies in the core catalog which we can replace by defining them as managed here

https://github.com/micronaut-projects/micronaut-core/blob/04e3b9486c7e6fecd0bc4557afc90bb6d9365c42/gradle/libs.versions.toml#L331-L335

To match the dependency names in core, I renamed 'spring-core' to simply 'spring'