### PR TITLE
Don't expose data source by default as it can conflict

### DIFF
--- a/spring-boot-starter/src/main/java/io/micronaut/spring/boot/starter/MicronautImportRegistrar.java
+++ b/spring-boot-starter/src/main/java/io/micronaut/spring/boot/starter/MicronautImportRegistrar.java
@@ -82,15 +82,6 @@ public final class MicronautImportRegistrar implements ImportBeanDefinitionRegis
 
     private final List<ExposedBeanData> exposedBeans = new ArrayList<>();
 
-    public MicronautImportRegistrar() {
-        exposedBeans.add(new ExposedBeanData(DataSource.class, null, null, (name) -> {
-            if ("dataSource".equals(name)) {
-                return "default";
-            }
-            return name;
-        }));
-    }
-
     @Override
     public void registerBeanDefinitions(
         AnnotationMetadata importingClassMetadata,

--- a/spring-boot-starter/src/test/java/io/micronaut/spring/boot/autconfigure/AutoConfigureMicronautTest.java
+++ b/spring-boot-starter/src/test/java/io/micronaut/spring/boot/autconfigure/AutoConfigureMicronautTest.java
@@ -23,9 +23,6 @@ public class AutoConfigureMicronautTest {
     DataSource dataSource;
 
     @Autowired
-    ReceiveDatasource datasource;
-
-    @Autowired
     ApplicationContext context;
 
     @Autowired
@@ -45,7 +42,3 @@ class Application {
 
 }
 
-@Singleton
-class ReceiveDatasource {
-    @Inject DataSource dataSource;
-}

--- a/spring-boot-starter/src/test/java/io/micronaut/spring/boot/customautoconfigure/AutoConfigureMicronautTest.java
+++ b/spring-boot-starter/src/test/java/io/micronaut/spring/boot/customautoconfigure/AutoConfigureMicronautTest.java
@@ -2,12 +2,16 @@ package io.micronaut.spring.boot.customautoconfigure;
 
 import java.util.Map;
 
+import javax.sql.DataSource;
+
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.spring.boot.starter.EnableMicronaut;
 import io.micronaut.spring.boot.starter.MicronautBeanFilter;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
@@ -20,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class AutoConfigureMicronautTest {
+    @Autowired
+    ReceiveDatasource datasource;
 
     @Autowired
     ApplicationContext context;
@@ -38,7 +44,9 @@ public class AutoConfigureMicronautTest {
 
 
 @SpringBootApplication
-@EnableMicronaut(filter = MyFilter.class)
+@EnableMicronaut(filter = MyFilter.class, exposeToMicronaut =  @EnableMicronaut.ExposedBean(
+    beanType = DataSource.class
+))
 class Application {
 
 }
@@ -48,4 +56,9 @@ class MyFilter implements MicronautBeanFilter {
     public boolean excludes(@NonNull BeanDefinition<?> definition) {
         return MediaTypeCodecRegistry.class.isAssignableFrom(definition.getBeanType());
     }
+}
+@Singleton
+class ReceiveDatasource {
+    @Inject
+    DataSource dataSource;
 }


### PR DESCRIPTION
Fixes the `NonUniqueBeanException` when Micronaut Data is included