### PR TITLE
ignore non-public import registrars

### DIFF
--- a/spring-annotation/build.gradle
+++ b/spring-annotation/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     testImplementation libs.managed.spring.tx
 }
 
-compileTestGroovy.options.forkOptions.jvmArgs =['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
-compileTestGroovy.options.fork=true
+//compileTestGroovy.options.forkOptions.jvmArgs =['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
+//compileTestGroovy.options.fork=true

--- a/spring-annotation/src/main/java/io/micronaut/spring/annotation/beans/ImportAnnotationVisitor.java
+++ b/spring-annotation/src/main/java/io/micronaut/spring/annotation/beans/ImportAnnotationVisitor.java
@@ -112,13 +112,16 @@ public final class ImportAnnotationVisitor implements TypeElementVisitor<Object,
 
     private void handleImportRegistrar(ClassElement originatingElement, ClassElement typeToImport, VisitorContext context) {
         // add the registrar as a bean
-        originatingElement
-            .addAssociatedBean(typeToImport)
-            .scope(AnnotationValue.builder(Singleton.class).build())
-            .annotate(ImportedBy.class, builder -> builder.member(
-                AnnotationMetadata.VALUE_MEMBER,
-                new AnnotationClassValue<>(originatingElement.getName())
-        ));
+        if (typeToImport.isPublic()) {
+            originatingElement
+                .addAssociatedBean(typeToImport)
+                .scope(AnnotationValue.builder(Singleton.class).build())
+                .annotate(ImportedBy.class, builder -> builder.member(
+                    AnnotationMetadata.VALUE_MEMBER,
+                    new AnnotationClassValue<>(originatingElement.getName())
+                ));
+        }
+
     }
 
     @Override

--- a/spring-boot-annotation/build.gradle
+++ b/spring-boot-annotation/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     testImplementation libs.managed.spring.boot
     testImplementation libs.spring.boot.autoconfigure
     testImplementation libs.spring.boot.actuator
+    testImplementation mn.micronaut.inject.java.test
 }

--- a/spring-boot-annotation/build.gradle
+++ b/spring-boot-annotation/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 plugins {
     id 'io.micronaut.build.internal.spring-module'
 }
@@ -14,4 +16,7 @@ dependencies {
     testImplementation libs.spring.boot.autoconfigure
     testImplementation libs.spring.boot.actuator
     testImplementation mn.micronaut.inject.java.test
+    if (!JavaVersion.current().isJava9Compatible()) {
+        testImplementation files(Jvm.current().toolsJar)
+    }
 }

--- a/spring-boot-annotation/src/test/groovy/io/micronaut/spring/boot/annotation/EntityScanSpec.groovy
+++ b/spring-boot-annotation/src/test/groovy/io/micronaut/spring/boot/annotation/EntityScanSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.spring.boot.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.spring.beans.ObjectProviderBeanDefinition
+
+class EntityScanSpec extends AbstractTypeElementSpec {
+    void "test @EntityScan"() {
+        given:
+        def context = buildContext("entityscan.Application",'''
+package entityscan;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Import;
+@SpringBootApplication
+@EntityScan("entityscan")
+class Application {
+}
+
+''', true)
+
+        expect:
+        context != null
+    }
+
+    @Override
+    List<BeanDefinitionReference<?>> getBuiltInBeanReferences() {
+        return super.getBuiltInBeanReferences() + [new ObjectProviderBeanDefinition()]
+    }
+}


### PR DESCRIPTION
Fixes IllegalAccessError when using `@EnittyScan`

```
Application$EntityScanPackages$Registrar0$Definition]: failed to access class org.springframework.boot.autoconfigure.domain.EntityScanPackages$Registrar from class 
```