### PR TITLE
fix: prevent ImportAnnotationVisitor walking non-visible classes

### DIFF
--- a/spring-annotation/src/main/java/io/micronaut/spring/annotation/beans/ImportAnnotationVisitor.java
+++ b/spring-annotation/src/main/java/io/micronaut/spring/annotation/beans/ImportAnnotationVisitor.java
@@ -74,17 +74,21 @@ public final class ImportAnnotationVisitor implements TypeElementVisitor<Object,
         if (annType != null && element.hasStereotype(annType)) {
             List<AnnotationValue<? extends Annotation>> values = element.getAnnotationValuesByType(annType);
             if (!values.isEmpty()) {
-                for (AnnotationValue<?> av : values) {
-                    AnnotationClassValue<?>[] acv = av.annotationClassValues(AnnotationMetadata.VALUE_MEMBER);
-                    for (AnnotationClassValue<?> a : acv) {
-                        String className = a.getName();
-                        context.getClassElement(className).ifPresent(typeToImport -> {
-                            if (typeToImport.isPublic()) {
-                                handleImport(element, context, typeToImport);
-                            }
-                        });
+                visitValues(element, context, values);
+            }
+        }
+    }
+
+    private void visitValues(ClassElement element, VisitorContext context, List<AnnotationValue<? extends Annotation>> values) {
+        for (AnnotationValue<?> av : values) {
+            AnnotationClassValue<?>[] acv = av.annotationClassValues(AnnotationMetadata.VALUE_MEMBER);
+            for (AnnotationClassValue<?> a : acv) {
+                String className = a.getName();
+                context.getClassElement(className).ifPresent(typeToImport -> {
+                    if (typeToImport.isPublic()) {
+                        handleImport(element, context, typeToImport);
                     }
-                }
+                });
             }
         }
     }

--- a/spring-annotation/src/main/java/io/micronaut/spring/annotation/beans/ImportAnnotationVisitor.java
+++ b/spring-annotation/src/main/java/io/micronaut/spring/annotation/beans/ImportAnnotationVisitor.java
@@ -58,8 +58,7 @@ import io.micronaut.spring.beans.ImportedBy;
 import io.micronaut.spring.core.type.ClassElementSpringMetadata;
 
 /**
- * Handles the import importDeclaration allowing importing of additional Spring beans into a Micronaut
- application.
+ * Handles the import importDeclaration allowing importing of additional Spring beans into a Micronaut application.
  *
  * @author graemerocher
  * @since 4.3.0
@@ -80,7 +79,9 @@ public final class ImportAnnotationVisitor implements TypeElementVisitor<Object,
                     for (AnnotationClassValue<?> a : acv) {
                         String className = a.getName();
                         context.getClassElement(className).ifPresent(typeToImport -> {
-                            handleImport(element, context, typeToImport);
+                            if (typeToImport.isPublic()) {
+                                handleImport(element, context, typeToImport);
+                            }
                         });
                     }
                 }


### PR DESCRIPTION
The ImportAnnotationVisitor would walk the spring hierarchy and cause package-private classes to have definitions created for them.

This would then fail at runtime, as Micronaut could not access these defined beans.

This fix only visits public classes to prevent this problem.

Closes #521

Added @dstepanov and @graemerocher as reviewers as although this fixes the issue, I'm not 100% sure on my understanding of the mechanisms at play here