### PR TITLE
Add support HttpExchange annotations

### DIFF
--- a/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/DeleteExchangeAnnotationTransformer.java
+++ b/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/DeleteExchangeAnnotationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.http.annotation.Delete;
+
+/**
+ * Maps Spring DeleteExchange to Micronaut.
+ *
+ * @since 5.10.0
+ */
+public class DeleteExchangeAnnotationTransformer extends HttpExchangeAnnotationTransformer {
+
+    @Override
+    public String getName() {
+        return "org.springframework.web.service.annotation.DeleteExchange";
+    }
+
+    @Override
+    protected AnnotationValueBuilder<?> newBuilder(String httpMethod) {
+        return AnnotationValue.builder(Delete.class);
+    }
+
+    @Override
+    protected boolean isHttpMethodMapping(String method) {
+        return true;
+    }
+}

--- a/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/GetExchangeAnnotationTransformer.java
+++ b/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/GetExchangeAnnotationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.http.annotation.Get;
+
+/**
+ * Maps Spring GetExchange to Micronaut.
+ *
+ * @since 5.10.0
+ */
+public class GetExchangeAnnotationTransformer extends HttpExchangeAnnotationTransformer {
+
+    @Override
+    public String getName() {
+        return "org.springframework.web.service.annotation.GetExchange";
+    }
+
+    @Override
+    protected AnnotationValueBuilder<?> newBuilder(String httpMethod) {
+        return AnnotationValue.builder(Get.class);
+    }
+
+    @Override
+    protected boolean isHttpMethodMapping(String method) {
+        return true;
+    }
+}

--- a/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/HttpExchangeAnnotationTransformer.java
+++ b/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/HttpExchangeAnnotationTransformer.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.spring.web.annotation;
+package io.micronaut.spring.web.annotation.exchange;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArrayUtils;
-import io.micronaut.http.HttpMethod;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
@@ -41,16 +41,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Maps Spring RequestMapping to Micronaut.
+ * Maps Spring HttpExchange to Micronaut.
  *
- * @author graemerocher
- * @since 1.0
+ * @since 5.10.0
  */
-public class RequestMappingAnnotationTransformer implements NamedAnnotationTransformer {
+public class HttpExchangeAnnotationTransformer implements NamedAnnotationTransformer {
 
     @Override
     public String getName() {
-        return "org.springframework.web.bind.annotation.RequestMapping";
+        return "org.springframework.web.service.annotation.HttpExchange";
     }
 
     /**
@@ -58,30 +57,28 @@ public class RequestMappingAnnotationTransformer implements NamedAnnotationTrans
      * @param method The method, can be null
      * @return True if it is
      */
-    protected boolean isHttpMethodMapping(@Nullable HttpMethod method) {
+    protected boolean isHttpMethodMapping(@Nullable String method) {
         return method != null;
     }
 
     /**
      * Construct a new builder for the given http method.
-     * @param httpMethod The method
-     * @param annotation The annotation
+     * @param method HTTP method
      * @return The builder
      */
-    protected @NonNull AnnotationValueBuilder<?> newBuilder(
-        @Nullable HttpMethod httpMethod,
-        AnnotationValue<Annotation> annotation) {
+    @NonNull
+    protected AnnotationValueBuilder<?> newBuilder(String method) {
 
-        if (httpMethod != null) {
-            return switch (httpMethod) {
-                case TRACE -> AnnotationValue.builder(Trace.class);
-                case DELETE -> AnnotationValue.builder(Delete.class);
-                case GET -> AnnotationValue.builder(Get.class);
-                case HEAD -> AnnotationValue.builder(Head.class);
-                case POST -> AnnotationValue.builder(Post.class);
-                case PUT -> AnnotationValue.builder(Put.class);
-                case PATCH -> AnnotationValue.builder(Patch.class);
-                case OPTIONS -> AnnotationValue.builder(Options.class);
+        if (method != null) {
+            return switch (method.toUpperCase()) {
+                case "GET" -> AnnotationValue.builder(Get.class);
+                case "POST" -> AnnotationValue.builder(Post.class);
+                case "PATCH" -> AnnotationValue.builder(Patch.class);
+                case "PUT" -> AnnotationValue.builder(Put.class);
+                case "DELETE" -> AnnotationValue.builder(Delete.class);
+                case "HEAD" -> AnnotationValue.builder(Head.class);
+                case "OPTIONS" -> AnnotationValue.builder(Options.class);
+                case "TRACE" -> AnnotationValue.builder(Trace.class);
                 default -> AnnotationValue.builder(UriMapping.class);
             };
         } else {
@@ -90,7 +87,7 @@ public class RequestMappingAnnotationTransformer implements NamedAnnotationTrans
     }
 
     private String computePath(AnnotationValue<Annotation> annotation) {
-        return annotation.stringValue().orElseGet(() -> annotation.stringValue("path").orElse(UriMapping.DEFAULT_URI));
+        return annotation.stringValue().orElseGet(() -> annotation.stringValue("url").orElse(UriMapping.DEFAULT_URI));
     }
 
     @Override
@@ -98,18 +95,18 @@ public class RequestMappingAnnotationTransformer implements NamedAnnotationTrans
         var annotations = new ArrayList<AnnotationValue<?>>();
 
         final String path = computePath(annotation);
-        var method = annotation.enumValue("method", HttpMethod.class).orElse(null);
+        var method = annotation.stringValue("method").orElse(null);
 
-        annotations.add(newBuilder(method, annotation).value(path).build());
+        annotations.add(newBuilder(method).value(path).build());
 
-        final String[] consumes = annotation.stringValues("consumes");
-        if (ArrayUtils.isNotEmpty(consumes)) {
-            annotations.add(AnnotationValue.builder(Consumes.class).member("value", consumes).build());
+        var contentType = annotation.stringValue("contentType").orElse(null);
+        if (StringUtils.isNotEmpty(contentType)) {
+            annotations.add(AnnotationValue.builder(Consumes.class).member("contentType", contentType).build());
         }
 
-        final String[] produces = annotation.stringValues("produces");
-        if (ArrayUtils.isNotEmpty(produces)) {
-            annotations.add(AnnotationValue.builder(Produces.class).member("value", produces).build());
+        final String[] accept = annotation.stringValues("accept");
+        if (ArrayUtils.isNotEmpty(accept)) {
+            annotations.add(AnnotationValue.builder(Produces.class).member("value", accept).build());
         }
 
         if (isHttpMethodMapping(method)) {

--- a/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/PatchExchangeAnnotationTransformer.java
+++ b/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/PatchExchangeAnnotationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.http.annotation.Patch;
+
+/**
+ * Maps Spring PatchExchange to Micronaut.
+ *
+ * @since 5.10.0
+ */
+public class PatchExchangeAnnotationTransformer extends HttpExchangeAnnotationTransformer {
+
+    @Override
+    public String getName() {
+        return "org.springframework.web.service.annotation.PatchExchange";
+    }
+
+    @Override
+    protected AnnotationValueBuilder<?> newBuilder(String httpMethod) {
+        return AnnotationValue.builder(Patch.class);
+    }
+
+    @Override
+    protected boolean isHttpMethodMapping(String method) {
+        return true;
+    }
+}

--- a/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/PostExchangeAnnotationTransformer.java
+++ b/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/PostExchangeAnnotationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.http.annotation.Post;
+
+/**
+ * Maps Spring PostExchange to Micronaut.
+ *
+ * @since 5.10.0
+ */
+public class PostExchangeAnnotationTransformer extends HttpExchangeAnnotationTransformer {
+
+    @Override
+    public String getName() {
+        return "org.springframework.web.service.annotation.PostExchange";
+    }
+
+    @Override
+    protected AnnotationValueBuilder<?> newBuilder(String httpMethod) {
+        return AnnotationValue.builder(Post.class);
+    }
+
+    @Override
+    protected boolean isHttpMethodMapping(String method) {
+        return true;
+    }
+}

--- a/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/PutExchangeAnnotationTransformer.java
+++ b/spring-web-annotation/src/main/java/io/micronaut/spring/web/annotation/exchange/PutExchangeAnnotationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.http.annotation.Put;
+
+/**
+ * Maps Spring PutExchange to Micronaut.
+ *
+ * @since 5.10.0
+ */
+public class PutExchangeAnnotationTransformer extends HttpExchangeAnnotationTransformer {
+
+    @Override
+    public String getName() {
+        return "org.springframework.web.service.annotation.PutExchange";
+    }
+
+    @Override
+    protected AnnotationValueBuilder<?> newBuilder(String httpMethod) {
+        return AnnotationValue.builder(Put.class);
+    }
+
+    @Override
+    protected boolean isHttpMethodMapping(String method) {
+        return true;
+    }
+}

--- a/spring-web-annotation/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/spring-web-annotation/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -4,3 +4,9 @@ io.micronaut.spring.web.annotation.PostMappingAnnotationTransformer
 io.micronaut.spring.web.annotation.PatchMappingAnnotationTransformer
 io.micronaut.spring.web.annotation.DeleteMappingAnnotationTransformer
 io.micronaut.spring.web.annotation.GetMappingAnnotationTransformer
+io.micronaut.spring.web.annotation.exchange.HttpExchangeAnnotationTransformer
+io.micronaut.spring.web.annotation.exchange.PutExchangeAnnotationTransformer
+io.micronaut.spring.web.annotation.exchange.PostExchangeAnnotationTransformer
+io.micronaut.spring.web.annotation.exchange.PatchExchangeAnnotationTransformer
+io.micronaut.spring.web.annotation.exchange.DeleteExchangeAnnotationTransformer
+io.micronaut.spring.web.annotation.exchange.GetExchangeAnnotationTransformer

--- a/spring-web/src/main/java/io/micronaut/spring/web/bind/RequestAttributeArgumentBinder.java
+++ b/spring-web/src/main/java/io/micronaut/spring/web/bind/RequestAttributeArgumentBinder.java
@@ -48,7 +48,7 @@ public class RequestAttributeArgumentBinder implements AnnotatedRequestArgumentB
                 annotationMetadata.getValue(RequestAttribute.class, "name", String.class).orElse(context.getArgument().getName())
         );
 
-        return new BindingResult<Object>() {
+        return new BindingResult<>() {
             @Override
             public Optional<Object> getValue() {
                 return source.getAttributes().get(name, context);

--- a/spring-web/src/test/groovy/io/micronaut/spring/web/annotation/exchange/ExchangeControllerSpec.groovy
+++ b/spring-web/src/test/groovy/io/micronaut/spring/web/annotation/exchange/ExchangeControllerSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.spring.web.annotation.Greeting
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.validation.ConstraintViolationException
+import spock.lang.Specification
+
+@MicronautTest
+class ExchangeControllerSpec extends Specification {
+
+    @Inject
+    ExchangeGreetingClient greetingClient
+
+    void "test request controller"() {
+        expect:
+        greetingClient.home().contains("Welcome to Micronaut for Spring")
+        greetingClient.greeting("Fred").content == 'Hello, Fred!'
+        greetingClient.greetingNested("Fred").content == 'Hello Nested, Fred!'
+        greetingClient.greeting(null).content == 'Hello, World!'
+        greetingClient.greetingByPost(new Greeting(1, "Fred")).content == 'Hello, Fred!'
+        greetingClient.greetingWithStatus("Fred")
+    }
+
+    void "test delete and response entity"() {
+        when:
+        HttpResponse<?> response = greetingClient.deleteGreeting()
+
+        then:
+        response.status() == HttpStatus.NO_CONTENT
+        response.header("Foo") == "Bar"
+        !response.header("myHeader")
+
+        when:
+        var myHeaderValue = "myHeaderValue"
+        response = greetingClient.deleteGreeting(myHeaderValue)
+
+        then:
+        response.status() == HttpStatus.NO_CONTENT
+        response.header("Foo") == "Bar"
+        response.header("myHeader") == myHeaderValue
+    }
+
+    void "test request controller validation"() {
+
+        when:
+        greetingClient.greeting("123").content == 'Hello, Fred!'
+
+        then:
+        def e = thrown(ConstraintViolationException)
+        e.message.contains('greeting.name: must match "\\D+"')
+    }
+
+    void "test ServerHttpRequest argument"() {
+
+        when:
+        Greeting greeting = greetingClient.requestTest(new Greeting(1, "Fred"))
+
+        then:
+        greeting != null
+    }
+
+    void "test optional pathVar"() {
+
+        when:
+        def responseForNull = greetingClient.withOptVar(null)
+
+        then:
+        responseForNull == 'optVar is null!'
+
+        when:
+        def response = greetingClient.withOptVar("This is path var")
+
+        then:
+        response == 'Hello, This is path var!'
+    }
+}

--- a/spring-web/src/test/java/io/micronaut/spring/web/annotation/NestedGreetingController.java
+++ b/spring-web/src/test/java/io/micronaut/spring/web/annotation/NestedGreetingController.java
@@ -24,12 +24,14 @@ import java.util.concurrent.atomic.AtomicLong;
 @RestController
 @RequestMapping("/nested")
 public class NestedGreetingController {
-    private static final String template = "Hello Nested, %s!";
+
+    private static final String TEMPLATE = "Hello Nested, %s!";
+
     private final AtomicLong counter = new AtomicLong();
 
     @RequestMapping("/greeting")
     public Greeting greeting(@RequestParam(value="name", defaultValue="World") String name) {
         return new Greeting(counter.incrementAndGet(),
-                String.format(template, name));
+            String.format(TEMPLATE, name));
     }
 }

--- a/spring-web/src/test/java/io/micronaut/spring/web/annotation/exchange/ExchangeGreetingApi.java
+++ b/spring-web/src/test/java/io/micronaut/spring/web/annotation/exchange/ExchangeGreetingApi.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.spring.web.annotation.Greeting;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.service.annotation.DeleteExchange;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface ExchangeGreetingApi {
+
+    @GetExchange
+    String home(@Nullable Model model);
+
+    @GetExchange("/withOptVar{/optVar}")
+    String withOptVar(@PathVariable(required = false) String optVar);
+
+    @GetExchange("/greeting2")
+    Greeting greeting(@RequestParam(value = "name", defaultValue = "World", required = false) @Pattern(regexp = "\\D+") String name);
+
+    @PostExchange("/greeting")
+    Greeting greetingByPost(@RequestBody Greeting greeting);
+
+    @DeleteExchange("/greeting")
+    HttpResponse<?> deleteGreeting(@RequestHeader(required = false) String myHeader);
+
+    @GetMapping("/greeting-status")
+    @ResponseStatus(code = HttpStatus.CREATED)
+    Greeting greetingWithStatus(@RequestParam(value = "name", defaultValue = "World") @Pattern(regexp = "\\D+") String name);
+
+    @GetMapping("/nested/greeting{?name}")
+    Greeting greetingNested(@RequestParam(value = "name", defaultValue = "World") String name);
+}

--- a/spring-web/src/test/java/io/micronaut/spring/web/annotation/exchange/ExchangeGreetingClient.java
+++ b/spring-web/src/test/java/io/micronaut/spring/web/annotation/exchange/ExchangeGreetingClient.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.spring.web.annotation.Greeting;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+@Client("/exchange")
+public interface ExchangeGreetingClient extends ExchangeGreetingApi {
+
+    @PostExchange("/request")
+    @Header(name = "Foo", value = "Bar")
+    Greeting requestTest(@RequestBody Greeting greeting);
+}

--- a/spring-web/src/test/java/io/micronaut/spring/web/annotation/exchange/ExchangeGreetingController.java
+++ b/spring-web/src/test/java/io/micronaut/spring/web/annotation/exchange/ExchangeGreetingController.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.spring.web.annotation.exchange;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.spring.web.annotation.Greeting;
+import jakarta.annotation.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.service.annotation.PostExchange;
+import reactor.core.publisher.Flux;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+
+@RestController
+@RequestMapping("/exchange")
+public class ExchangeGreetingController implements ExchangeGreetingApi {
+
+    private static final String TEMPLATE_NESTED = "Hello Nested, %s!";
+    private static final String TEMPLATE = "Hello, %s!";
+
+    private final AtomicLong counter = new AtomicLong();
+
+    @Override
+    public String home(@Nullable Model model) {
+        model.addAttribute("message", "Welcome to Micronaut for Spring!");
+        return "welcome";
+    }
+
+    @Override
+    public String withOptVar(@Nullable String optVar) {
+        return optVar == null ? "optVar is null!" : String.format(TEMPLATE, optVar);
+    }
+
+    @Override
+    public Greeting greeting(@Nullable String name) {
+        return new Greeting(counter.incrementAndGet(), TEMPLATE.formatted(name));
+    }
+
+    @Override
+    public Greeting greetingByPost(Greeting greeting) {
+        return new Greeting(counter.incrementAndGet(), TEMPLATE.formatted(greeting.getContent()));
+    }
+
+    @Override
+    public HttpResponse<?> deleteGreeting(@Nullable String myHeader) {
+        var headers = new HashMap<CharSequence, CharSequence>();
+        headers.put("Foo", "Bar");
+        if (myHeader != null) {
+            headers.put("myHeader", myHeader);
+        }
+        return HttpResponse.noContent().headers(headers);
+    }
+
+    @Override
+    public Greeting greetingWithStatus(String name) {
+        return new Greeting(counter.incrementAndGet(), TEMPLATE.formatted(name));
+    }
+
+    @Override
+    public Greeting greetingNested(String name) {
+        return new Greeting(counter.incrementAndGet(), String.format(TEMPLATE_NESTED, name));
+    }
+
+    @PostExchange("/request")
+    public Flux<String> request(ServerHttpRequest request, HttpMethod method) {
+        assertEquals("/exchange/request", request.getPath().value());
+        assertEquals(HttpMethod.POST, request.getMethod());
+        assertEquals(HttpMethod.POST, method);
+        assertEquals("Bar", request.getHeaders().getFirst("Foo"));
+        return request.getBody().map(dataBuffer -> {
+            var bytes = new byte[dataBuffer.readableByteCount()];
+            dataBuffer.read(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
+        });
+    }
+}

--- a/src/main/docs/guide/springToMicronaut/springMvc.adoc
+++ b/src/main/docs/guide/springToMicronaut/springMvc.adoc
@@ -58,6 +58,30 @@ The following Spring MVC annotations are supported:
 |link:{micronautapi}http/annotation/Controller.html[@Controller]
 |Example `@RestController`
 
+|link:{springapi}org/springframework/web/service/annotation/HttpExchange.html[@HttpExchange]
+|link:{micronautapi}http/annotation/UriMapping.html[@UriMapping]
+|Example: `@HttpExchange("/foo/bar")`
+
+    |link:{springapi}org/springframework/web/service/annotation/GetExchange.html[@GetExchange]
+|link:{micronautapi}http/annotation/Get.html[@Get]
+|Example: `@GetExchange("/foo/bar")`
+
+|link:{springapi}org/springframework/web/service/annotation/PostExchange.html[@PostExchange]
+|link:{micronautapi}http/annotation/Post.html[@Post]
+|Example: `@PostExchange("/foo/bar")`
+
+|link:{springapi}org/springframework/web/service/annotation/DeleteExchange.html[@DeleteExchange]
+|link:{micronautapi}http/annotation/Delete.html[@Delete]
+|Example: `@DeleteExchange("/foo/bar")`
+
+|link:{springapi}org/springframework/web/service/annotation/PatchExchange.html[@PatchExchange]
+|link:{micronautapi}http/annotation/Patch.html[@Patch]
+|Example: `@PatchExchange("/foo/bar")`
+
+|link:{springapi}org/springframework/web/service/annotation/PutExchange.html[@PutExchange]
+|link:{micronautapi}http/annotation/Put.html[@Put]
+|Example: `@PutExchange("/foo/bar")`
+
 |link:{springapi}org/springframework/web/bind/annotation/RequestMapping.html[@RequestMapping]
 |link:{micronautapi}http/annotation/UriMapping.html[@UriMapping]
 |Example: `@RequestMapping("/foo/bar")`


### PR DESCRIPTION
It's not full support of these annotations, because they primarily describe the client's behavior, i.e. describe its requests for specific endpoints. But Spring allows using these annotations to describe a single API interface. Therefore, it is important for us to have correct mapping of these annotations specifically for the server, i.e. when they are used in the controller to describe endpoints.

This is necessary, for example, for micronaut-openapi , so that it correctly understands the description of endpoints on the server side.

@dstepanov @graemerocher @sdelamo 