### PR TITLE
Dependency cleanup in `micronaut-spring-context`

### DIFF
--- a/spring-context/build.gradle.kts
+++ b/spring-context/build.gradle.kts
@@ -8,11 +8,12 @@ dependencies {
     api(mn.micronaut.inject)
     api(projects.micronautSpring)
 
-    implementation(mnCache.micronaut.cache.core)
+    implementation(mn.micronaut.context)
 
     testAnnotationProcessor(mn.micronaut.inject.java)
     testAnnotationProcessor(projects.micronautSpringAnnotation)
 
+    testImplementation(mnCache.micronaut.cache.core)
     testImplementation(mn.micronaut.jackson.databind)
     testImplementation(mn.micronaut.runtime)
     testImplementation(mn.micronaut.inject.java)

--- a/spring-context/src/test/groovy/io/micronaut/spring/annotation/context/BeanFactorySpec.groovy
+++ b/spring-context/src/test/groovy/io/micronaut/spring/annotation/context/BeanFactorySpec.groovy
@@ -17,8 +17,6 @@ package io.micronaut.spring.annotation.context
 
 import io.micronaut.context.env.Environment
 import io.micronaut.spring.context.MicronautApplicationContext
-import io.micronaut.spring.context.factory.MicronautBeanFactory
-import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import spock.lang.Specification
 

--- a/spring-context/src/test/groovy/io/micronaut/spring/annotation/context/CacheAnnotationMappingSpec.groovy
+++ b/spring-context/src/test/groovy/io/micronaut/spring/annotation/context/CacheAnnotationMappingSpec.groovy
@@ -19,7 +19,6 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.cache.annotation.CachePut
 import io.micronaut.cache.annotation.Cacheable
 import io.micronaut.context.ApplicationContext
-import io.micronaut.inject.BeanDefinition
 import org.springframework.cache.annotation.CacheEvict
 
 class CacheAnnotationMappingSpec extends AbstractTypeElementSpec {
@@ -44,12 +43,12 @@ class MyBean {
     String testCache() {
         return null;
     }
-    
+
     @CacheEvict("test")
     public String testCacheEvict() {
         return null;
     }
-    
+
     @CachePut("test")
     String testCachePut() {
         return null;

--- a/spring-context/src/test/groovy/io/micronaut/spring/annotation/context/ConfigurationAnnotationMappingSpec.groovy
+++ b/spring-context/src/test/groovy/io/micronaut/spring/annotation/context/ConfigurationAnnotationMappingSpec.groovy
@@ -2,7 +2,6 @@ package io.micronaut.spring.annotation.context
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
-import io.micronaut.inject.BeanDefinition
 import io.micronaut.spring.context.aop.SpringConfigurationInterceptor
 
 class ConfigurationAnnotationMappingSpec extends AbstractTypeElementSpec {

--- a/spring-context/src/test/groovy/io/micronaut/spring/core/type/SpringMetadataSpec.groovy
+++ b/spring-context/src/test/groovy/io/micronaut/spring/core/type/SpringMetadataSpec.groovy
@@ -1,9 +1,6 @@
 package io.micronaut.spring.core.type
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.context.annotation.Bean
-import io.micronaut.core.util.StringUtils
-import io.micronaut.inject.ast.ClassElement
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Indexed


### PR DESCRIPTION
When looking at the dependencies in `micronaut-spring-context` while using it in the new `grails-micronaut` plugin, it occurred to me that `micronaut-spring-context` might bring in unnecessary transitive dependencies.