### PR TITLE
Clear ResponseEntity body when Spring body is null

### DIFF
--- a/spring-web/src/main/java/io/micronaut/spring/web/ResponseEntityServerFilter.java
+++ b/spring-web/src/main/java/io/micronaut/spring/web/ResponseEntityServerFilter.java
@@ -55,10 +55,7 @@ public class ResponseEntityServerFilter implements HttpServerFilter {
                         }
                     }
                 });
-                final Object b = entity.getBody();
-                if (b != null) {
-                    mutableHttpResponse.body(b);
-                }
+                mutableHttpResponse.body(entity.getBody());
             } else if (body instanceof HttpHeaders httpHeaders) {
                 mutableHttpResponse.body(null);
                 httpHeaders.forEach((s, strings) -> {

--- a/spring-web/src/test/groovy/io/micronaut/spring/web/annotation/RestControllerSpec.groovy
+++ b/spring-web/src/test/groovy/io/micronaut/spring/web/annotation/RestControllerSpec.groovy
@@ -47,6 +47,7 @@ class RestControllerSpec extends Specification {
         response.status() == HttpStatus.NO_CONTENT
         response.header("Foo") == "Bar"
         !response.header("myHeader")
+        response.getBody().isEmpty()
 
         when:
         var myHeaderValue = "myHeaderValue"
@@ -56,6 +57,7 @@ class RestControllerSpec extends Specification {
         response.status() == HttpStatus.NO_CONTENT
         response.header("Foo") == "Bar"
         response.header("myHeader") == myHeaderValue
+        response.getBody().isEmpty()
     }
 
     void "test request controller validation"() {


### PR DESCRIPTION
Fixes ResponseEntity handling for no-body Spring responses such as 204 NO_CONTENT. ResponseEntityServerFilter already copied status and headers, but left the original ResponseEntity object as the Micronaut body when entity.getBody() was null, which could later be serialized as JSON. This clears the Micronaut response body in that case.

Regression coverage adds empty-body assertions to the existing ResponseEntity delete route test.

Validation:
- ./gradlew :micronaut-spring-web:test --tests io.micronaut.spring.web.annotation.RestControllerSpec --stacktrace